### PR TITLE
Add retries to blob fetching

### DIFF
--- a/archiver/service/archiver_test.go
+++ b/archiver/service/archiver_test.go
@@ -295,8 +295,8 @@ func TestArchiver_LatestHaltsOnPersistentError(t *testing.T) {
 	fs.CheckNotExistsOrFail(t, blobtest.Four)
 	fs.CheckExistsOrFail(t, blobtest.Three)
 
-	// One failure is retried
-	fs.WritesFailTimes(maxLiveAttempts + 1)
+	// Retries the maximum number of times, then fails and will not write the blobs
+	fs.WritesFailTimes(liveFetchBlobMaximumRetries + 1)
 	svc.processBlocksUntilKnownBlock(context.Background())
 
 	fs.CheckNotExistsOrFail(t, blobtest.Five)

--- a/common/storage/storagetest/stub.go
+++ b/common/storage/storagetest/stub.go
@@ -12,6 +12,7 @@ import (
 
 type TestFileStorage struct {
 	*storage.FileStorage
+	writeFailCount int
 }
 
 func NewTestFileStorage(t *testing.T, l log.Logger) *TestFileStorage {
@@ -19,6 +20,19 @@ func NewTestFileStorage(t *testing.T, l log.Logger) *TestFileStorage {
 	return &TestFileStorage{
 		FileStorage: storage.NewFileStorage(dir, l),
 	}
+}
+
+func (s *TestFileStorage) WritesFailTimes(times int) {
+	s.writeFailCount = times
+}
+
+func (s *TestFileStorage) Write(_ context.Context, data storage.BlobData) error {
+	if s.writeFailCount > 0 {
+		s.writeFailCount--
+		return storage.ErrStorage
+	}
+
+	return s.FileStorage.Write(context.Background(), data)
 }
 
 func (fs *TestFileStorage) CheckExistsOrFail(t *testing.T, hash common.Hash) {


### PR DESCRIPTION
### Description
This PR adds retries to the following cases:

* Fetching & storing the current head on startup
* Live indexing of new blobs

For the live indexing case, assuming the chain state is the following state:

```
Beacon chain blocks:
3 -> 4 -> 5

head=5
lastArchivedBlock=3
```

* If persisting blob 5 succeeds, but blob 4 fails, currently blob 4 wont be retried as part of live indexing and will need to be explicitly be rearchived. The additional retries reduce the likelihood of this happening due to transient errors.
* If persisting blob 5 fails, this reduces the delay before it's retried (the poller is default configuration is 6s)
