### PR TITLE
Add Rearchive API

### DIFF
--- a/archiver/cmd/main.go
+++ b/archiver/cmd/main.go
@@ -66,9 +66,14 @@ func Main() cliapp.LifecycleAction {
 			return nil, err
 		}
 
-		api := service.NewAPI(m, l)
-
 		l.Info("Initializing Archiver Service")
-		return service.NewService(l, cfg, api, storageClient, beaconClient, m)
+		archiver, err := service.NewArchiver(l, cfg, storageClient, beaconClient, m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize archiver: %w", err)
+		}
+
+		api := service.NewAPI(m, l, archiver)
+
+		return service.NewService(l, cfg, api, archiver, m)
 	}
 }

--- a/archiver/metrics/metrics.go
+++ b/archiver/metrics/metrics.go
@@ -11,8 +11,9 @@ type BlockSource string
 var (
 	MetricsNamespace = "blob_archiver"
 
-	BlockSourceBackfill BlockSource = "backfill"
-	BlockSourceLive     BlockSource = "live"
+	BlockSourceBackfill  BlockSource = "backfill"
+	BlockSourceLive      BlockSource = "live"
+	BlockSourceRearchive BlockSource = "rearchive"
 )
 
 type Metricer interface {

--- a/archiver/service/api_test.go
+++ b/archiver/service/api_test.go
@@ -1,23 +1,32 @@
 package service
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/base-org/blob-archiver/archiver/flags"
 	"github.com/base-org/blob-archiver/archiver/metrics"
+	"github.com/base-org/blob-archiver/common/storage/storagetest"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
-func setupAPI(t *testing.T) *API {
+func setupAPI(t *testing.T) (*API, *storagetest.TestFileStorage) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	m := metrics.NewMetrics()
-	return NewAPI(m, logger)
+	fs := storagetest.NewTestFileStorage(t, logger)
+	archiver, err := NewArchiver(logger, flags.ArchiverConfig{
+		PollInterval: 10 * time.Second,
+	}, fs, nil, m)
+	require.NoError(t, err)
+	return NewAPI(m, logger, archiver), fs
 }
 
 func TestHealthHandler(t *testing.T) {
-	a := setupAPI(t)
+	a, _ := setupAPI(t)
 
 	request := httptest.NewRequest("GET", "/healthz", nil)
 	response := httptest.NewRecorder()
@@ -25,4 +34,72 @@ func TestHealthHandler(t *testing.T) {
 	a.router.ServeHTTP(response, request)
 
 	require.Equal(t, 200, response.Code)
+}
+
+func TestReindexHandler(t *testing.T) {
+	a, _ := setupAPI(t)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		error          string
+	}{
+		{
+			name:           "should fail with no params",
+			path:           "/reindex",
+			expectedStatus: 400,
+			error:          "invalid from param: must provide param",
+		},
+		{
+			name:           "should fail with missing to param",
+			path:           "/reindex?from=1",
+			expectedStatus: 400,
+			error:          "invalid to param: must provide param",
+		},
+		{
+			name:           "should fail with missing from param",
+			path:           "/reindex?to=1",
+			expectedStatus: 400,
+			error:          "invalid from param: must provide param",
+		},
+		{
+			name:           "should fail with invalid from param",
+			path:           "/reindex?from=blah&to=1",
+			expectedStatus: 400,
+			error:          "invalid from param: invalid slot: \"blah\"",
+		},
+		{
+			name:           "should fail with invalid to param",
+			path:           "/reindex?from=1&to=blah",
+			expectedStatus: 400,
+			error:          "invalid to param: invalid slot: \"blah\"",
+		},
+		{
+			name:           "should fail with to greater than equal to from",
+			path:           "/reindex?from=2&to=1",
+			expectedStatus: 400,
+			error:          "invalid range: from 2 to 1",
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest("POST", test.path, nil)
+			response := httptest.NewRecorder()
+
+			a.router.ServeHTTP(response, request)
+
+			require.Equal(t, test.expectedStatus, response.Code)
+
+			var errResponse reindexResponse
+			err := json.NewDecoder(response.Body).Decode(&errResponse)
+			require.NoError(t, err)
+
+			if test.error != "" {
+				require.Equal(t, errResponse.Error, test.error)
+			}
+		})
+	}
 }

--- a/archiver/service/api_test.go
+++ b/archiver/service/api_test.go
@@ -36,7 +36,7 @@ func TestHealthHandler(t *testing.T) {
 	require.Equal(t, 200, response.Code)
 }
 
-func TestReindexHandler(t *testing.T) {
+func TestRearchiveHandler(t *testing.T) {
 	a, _ := setupAPI(t)
 
 	tests := []struct {
@@ -47,37 +47,37 @@ func TestReindexHandler(t *testing.T) {
 	}{
 		{
 			name:           "should fail with no params",
-			path:           "/reindex",
+			path:           "/rearchive",
 			expectedStatus: 400,
 			error:          "invalid from param: must provide param",
 		},
 		{
 			name:           "should fail with missing to param",
-			path:           "/reindex?from=1",
+			path:           "/rearchive?from=1",
 			expectedStatus: 400,
 			error:          "invalid to param: must provide param",
 		},
 		{
 			name:           "should fail with missing from param",
-			path:           "/reindex?to=1",
+			path:           "/rearchive?to=1",
 			expectedStatus: 400,
 			error:          "invalid from param: must provide param",
 		},
 		{
 			name:           "should fail with invalid from param",
-			path:           "/reindex?from=blah&to=1",
+			path:           "/rearchive?from=blah&to=1",
 			expectedStatus: 400,
 			error:          "invalid from param: invalid slot: \"blah\"",
 		},
 		{
 			name:           "should fail with invalid to param",
-			path:           "/reindex?from=1&to=blah",
+			path:           "/rearchive?from=1&to=blah",
 			expectedStatus: 400,
 			error:          "invalid to param: invalid slot: \"blah\"",
 		},
 		{
 			name:           "should fail with to greater than equal to from",
-			path:           "/reindex?from=2&to=1",
+			path:           "/rearchive?from=2&to=1",
 			expectedStatus: 400,
 			error:          "invalid range: from 2 to 1",
 		},
@@ -93,7 +93,7 @@ func TestReindexHandler(t *testing.T) {
 
 			require.Equal(t, test.expectedStatus, response.Code)
 
-			var errResponse reindexResponse
+			var errResponse rearchiveResponse
 			err := json.NewDecoder(response.Body).Decode(&errResponse)
 			require.NoError(t, err)
 

--- a/archiver/service/service.go
+++ b/archiver/service/service.go
@@ -41,10 +41,7 @@ type ArchiverService struct {
 	archiver      *Archiver
 }
 
-// Start starts the archiver service. It begins polling the beacon node for the latest blocks and persisting blobs for
-// them. Concurrently it'll also begin a backfill process (see backfillBlobs) to store all blobs from the current head
-// to the previously stored blocks. This ensures that during restarts or outages of an archiver, any gaps will be
-// filled in.
+// Start starts the archiver service. It'll start the API's as well as the archiving process.
 func (a *ArchiverService) Start(ctx context.Context) error {
 	if a.cfg.MetricsConfig.Enabled {
 		a.log.Info("starting metrics server", "addr", a.cfg.MetricsConfig.ListenAddr, "port", a.cfg.MetricsConfig.ListenPort)

--- a/archiver/service/service.go
+++ b/archiver/service/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	client "github.com/attestantio/go-eth2-client"
 	"github.com/base-org/blob-archiver/archiver/flags"
 	"github.com/base-org/blob-archiver/archiver/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -15,11 +14,6 @@ import (
 )
 
 var ErrAlreadyStopped = errors.New("already stopped")
-
-type BeaconClient interface {
-	client.BlobSidecarsProvider
-	client.BeaconBlockHeadersProvider
-}
 
 func NewService(l log.Logger, cfg flags.ArchiverConfig, api *API, archiver *Archiver, m metrics.Metricer) (*ArchiverService, error) {
 	return &ArchiverService{

--- a/archiver/service/service.go
+++ b/archiver/service/service.go
@@ -1,0 +1,89 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	client "github.com/attestantio/go-eth2-client"
+	"github.com/base-org/blob-archiver/archiver/flags"
+	"github.com/base-org/blob-archiver/archiver/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var ErrAlreadyStopped = errors.New("already stopped")
+
+type BeaconClient interface {
+	client.BlobSidecarsProvider
+	client.BeaconBlockHeadersProvider
+}
+
+func NewService(l log.Logger, cfg flags.ArchiverConfig, api *API, archiver *Archiver, m metrics.Metricer) (*ArchiverService, error) {
+	return &ArchiverService{
+		log:      l,
+		cfg:      cfg,
+		archiver: archiver,
+		metrics:  m,
+		api:      api,
+	}, nil
+}
+
+type ArchiverService struct {
+	stopped       atomic.Bool
+	log           log.Logger
+	metricsServer *httputil.HTTPServer
+	cfg           flags.ArchiverConfig
+	metrics       metrics.Metricer
+	api           *API
+	archiver      *Archiver
+}
+
+// Start starts the archiver service. It begins polling the beacon node for the latest blocks and persisting blobs for
+// them. Concurrently it'll also begin a backfill process (see backfillBlobs) to store all blobs from the current head
+// to the previously stored blocks. This ensures that during restarts or outages of an archiver, any gaps will be
+// filled in.
+func (a *ArchiverService) Start(ctx context.Context) error {
+	if a.cfg.MetricsConfig.Enabled {
+		a.log.Info("starting metrics server", "addr", a.cfg.MetricsConfig.ListenAddr, "port", a.cfg.MetricsConfig.ListenPort)
+		srv, err := opmetrics.StartServer(a.metrics.Registry(), a.cfg.MetricsConfig.ListenAddr, a.cfg.MetricsConfig.ListenPort)
+		if err != nil {
+			return err
+		}
+
+		a.log.Info("started metrics server", "addr", srv.Addr())
+		a.metricsServer = srv
+	}
+
+	srv, err := httputil.StartHTTPServer(a.cfg.ListenAddr, a.api.router)
+	if err != nil {
+		return fmt.Errorf("failed to start Archiver API server: %w", err)
+	}
+
+	a.log.Info("Archiver API server started", "address", srv.Addr().String())
+
+	return a.archiver.Start(ctx)
+}
+
+// Stops the archiver service.
+func (a *ArchiverService) Stop(ctx context.Context) error {
+	if a.stopped.Load() {
+		return ErrAlreadyStopped
+	}
+	a.log.Info("Stopping Archiver")
+	a.stopped.Store(true)
+
+	if a.metricsServer != nil {
+		if err := a.metricsServer.Stop(ctx); err != nil {
+			return err
+		}
+	}
+
+	return a.archiver.Stop(ctx)
+}
+
+func (a *ArchiverService) Stopped() bool {
+	return a.stopped.Load()
+}

--- a/common/beacon/beacontest/stub.go
+++ b/common/beacon/beacontest/stub.go
@@ -3,6 +3,7 @@ package beacontest
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/api"
@@ -61,16 +62,29 @@ func NewDefaultStubBeaconClient(t *testing.T) *StubBeaconClient {
 	headBlobs := blobtest.NewBlobSidecars(t, 6)
 	finalizedBlobs := blobtest.NewBlobSidecars(t, 4)
 
+	startSlot := blobtest.StartSlot
+
 	return &StubBeaconClient{
 		Headers: map[string]*v1.BeaconBlockHeader{
-			blobtest.OriginBlock.String(): makeHeader(10, blobtest.OriginBlock, common.Hash{9, 9, 9}),
-			blobtest.One.String():         makeHeader(11, blobtest.One, blobtest.OriginBlock),
-			blobtest.Two.String():         makeHeader(12, blobtest.Two, blobtest.One),
-			blobtest.Three.String():       makeHeader(13, blobtest.Three, blobtest.Two),
-			blobtest.Four.String():        makeHeader(14, blobtest.Four, blobtest.Three),
-			blobtest.Five.String():        makeHeader(15, blobtest.Five, blobtest.Four),
-			"head":                        makeHeader(15, blobtest.Five, blobtest.Four),
-			"finalized":                   makeHeader(13, blobtest.Three, blobtest.Two),
+			// Lookup by hash
+			blobtest.OriginBlock.String(): makeHeader(startSlot, blobtest.OriginBlock, common.Hash{9, 9, 9}),
+			blobtest.One.String():         makeHeader(startSlot+1, blobtest.One, blobtest.OriginBlock),
+			blobtest.Two.String():         makeHeader(startSlot+2, blobtest.Two, blobtest.One),
+			blobtest.Three.String():       makeHeader(startSlot+3, blobtest.Three, blobtest.Two),
+			blobtest.Four.String():        makeHeader(startSlot+4, blobtest.Four, blobtest.Three),
+			blobtest.Five.String():        makeHeader(startSlot+5, blobtest.Five, blobtest.Four),
+
+			// Lookup by identifier
+			"head":      makeHeader(startSlot+5, blobtest.Five, blobtest.Four),
+			"finalized": makeHeader(startSlot+3, blobtest.Three, blobtest.Two),
+
+			// Lookup by slot
+			strconv.FormatUint(startSlot, 10):   makeHeader(startSlot, blobtest.OriginBlock, common.Hash{9, 9, 9}),
+			strconv.FormatUint(startSlot+1, 10): makeHeader(startSlot+1, blobtest.One, blobtest.OriginBlock),
+			strconv.FormatUint(startSlot+2, 10): makeHeader(startSlot+2, blobtest.Two, blobtest.One),
+			strconv.FormatUint(startSlot+3, 10): makeHeader(startSlot+3, blobtest.Three, blobtest.Two),
+			strconv.FormatUint(startSlot+4, 10): makeHeader(startSlot+4, blobtest.Four, blobtest.Three),
+			strconv.FormatUint(startSlot+5, 10): makeHeader(startSlot+5, blobtest.Five, blobtest.Four),
 		},
 		Blobs: map[string][]*deneb.BlobSidecar{
 			blobtest.OriginBlock.String(): blobtest.NewBlobSidecars(t, 1),

--- a/common/blobtest/helpers.go
+++ b/common/blobtest/helpers.go
@@ -17,6 +17,8 @@ var (
 	Three       = common.Hash{3}
 	Four        = common.Hash{4}
 	Five        = common.Hash{5}
+
+	StartSlot = uint64(10)
 )
 
 func RandBytes(t *testing.T, size uint) []byte {


### PR DESCRIPTION
### Description
This PR adds a new API on the archiver process `POST /rearchive?from=<slot>&to=<slot>`. When invoked this API will travese all the slots in this range and overwrite the data stored in the data store.

The majority of the changes in this PR is splitting the archiving logic out of the service and moving it into it's own `Archiver` struct in `archiver.go`. This allows both the API and background job to interact with the archiving logic.