### PR TITLE
validator: emit more verbose log info

### DIFF
--- a/validator/service/service.go
+++ b/validator/service/service.go
@@ -136,7 +136,7 @@ func (a *ValidatorService) checkBlobs(ctx context.Context, start phase0.Slot, en
 
 			if beaconStatus != http.StatusOK {
 				// This can happen if the slot has been missed
-				l.Info("matching error status", "beacon", beaconStatus, "blob", blobStatus)
+				l.Info("matching error status", "beaconStatus", beaconStatus, "blobStatus", blobStatus)
 				continue
 
 			}


### PR DESCRIPTION
A minor one, but this harmonises the output with other http code logging, and reduces the chance of confusion with log lines which output the number of blobs.