### PR TITLE
Add test for comma separated query param indices

### DIFF
--- a/api/service/api_test.go
+++ b/api/service/api_test.go
@@ -181,6 +181,14 @@ func TestAPIService(t *testing.T) {
 			},
 		},
 		{
+			name:   "multi indices comma separated list",
+			path:   "/eth/v1/beacon/blob_sidecars/1234?indices=0,1",
+			status: 200,
+			expected: &storage.BlobSidecars{
+				Data: blockTwo.BlobSidecars.Data,
+			},
+		},
+		{
 			name:       "only index out of bounds returns empty array",
 			path:       "/eth/v1/beacon/blob_sidecars/1234?indices=3",
 			status:     400,


### PR DESCRIPTION
Related to https://github.com/base-org/blob-archiver/pull/22.

Adds a regression test to ensure the `indices` query param can be set to multiple values via a comma separated list and an array.