### PR TITLE
Add validator flags for configurable hours of blob data

### DIFF
--- a/validator/cmd/main.go
+++ b/validator/cmd/main.go
@@ -59,6 +59,6 @@ func Main() cliapp.LifecycleAction {
 		beaconClient := service.NewBlobSidecarClient(cfg.BeaconConfig.BeaconURL)
 		blobClient := service.NewBlobSidecarClient(cfg.BlobConfig.BeaconURL)
 
-		return service.NewValidator(l, headerClient, beaconClient, blobClient, closeApp, cfg.BlocksPerMinuteConfig*cfg.HoursOfBlobDataConfig*60), nil
+		return service.NewValidator(l, headerClient, beaconClient, blobClient, closeApp, cfg.NumBlocks), nil
 	}
 }

--- a/validator/cmd/main.go
+++ b/validator/cmd/main.go
@@ -59,6 +59,6 @@ func Main() cliapp.LifecycleAction {
 		beaconClient := service.NewBlobSidecarClient(cfg.BeaconConfig.BeaconURL)
 		blobClient := service.NewBlobSidecarClient(cfg.BlobConfig.BeaconURL)
 
-		return service.NewValidator(l, headerClient, beaconClient, blobClient, closeApp), nil
+		return service.NewValidator(l, headerClient, beaconClient, blobClient, closeApp, cfg.BlocksPerMinuteConfig*cfg.HoursOfBlobDataConfig*60), nil
 	}
 }

--- a/validator/flags/config.go
+++ b/validator/flags/config.go
@@ -10,11 +10,10 @@ import (
 )
 
 type ValidatorConfig struct {
-	LogConfig             oplog.CLIConfig
-	BeaconConfig          common.BeaconConfig
-	BlobConfig            common.BeaconConfig
-	BlocksPerMinuteConfig int
-	HoursOfBlobDataConfig int
+	LogConfig    oplog.CLIConfig
+	BeaconConfig common.BeaconConfig
+	BlobConfig   common.BeaconConfig
+	NumBlocks    int
 }
 
 func (c ValidatorConfig) Check() error {
@@ -26,12 +25,8 @@ func (c ValidatorConfig) Check() error {
 		return fmt.Errorf("blob config check failed: %w", err)
 	}
 
-	if c.BlocksPerMinuteConfig <= 0 {
-		return fmt.Errorf("blocks per minute must be greater than 0")
-	}
-
-	if c.HoursOfBlobDataConfig <= 0 {
-		return fmt.Errorf("hours of blob data must be greater than 0")
+	if c.NumBlocks <= 0 {
+		return fmt.Errorf("number of blocks must be greater than 0")
 	}
 
 	return nil
@@ -50,7 +45,6 @@ func ReadConfig(cliCtx *cli.Context) ValidatorConfig {
 			BeaconURL:           cliCtx.String(BlobApiClientUrlFlag.Name),
 			BeaconClientTimeout: timeout,
 		},
-		BlocksPerMinuteConfig: cliCtx.Int(BeaconClientTimeoutFlag.Name),
-		HoursOfBlobDataConfig: cliCtx.Int(HoursOfBlobDataClientFlag.Name),
+		NumBlocks: cliCtx.Int(NumBlocksClientFlag.Name),
 	}
 }

--- a/validator/flags/config.go
+++ b/validator/flags/config.go
@@ -10,9 +10,11 @@ import (
 )
 
 type ValidatorConfig struct {
-	LogConfig    oplog.CLIConfig
-	BeaconConfig common.BeaconConfig
-	BlobConfig   common.BeaconConfig
+	LogConfig             oplog.CLIConfig
+	BeaconConfig          common.BeaconConfig
+	BlobConfig            common.BeaconConfig
+	BlocksPerMinuteConfig int
+	HoursOfBlobDataConfig int
 }
 
 func (c ValidatorConfig) Check() error {
@@ -22,6 +24,14 @@ func (c ValidatorConfig) Check() error {
 
 	if err := c.BlobConfig.Check(); err != nil {
 		return fmt.Errorf("blob config check failed: %w", err)
+	}
+
+	if c.BlocksPerMinuteConfig <= 0 {
+		return fmt.Errorf("blocks per minute must be greater than 0")
+	}
+
+	if c.HoursOfBlobDataConfig <= 0 {
+		return fmt.Errorf("hours of blob data must be greater than 0")
 	}
 
 	return nil
@@ -40,5 +50,7 @@ func ReadConfig(cliCtx *cli.Context) ValidatorConfig {
 			BeaconURL:           cliCtx.String(BlobApiClientUrlFlag.Name),
 			BeaconClientTimeout: timeout,
 		},
+		BlocksPerMinuteConfig: cliCtx.Int(BeaconClientTimeoutFlag.Name),
+		HoursOfBlobDataConfig: cliCtx.Int(HoursOfBlobDataClientFlag.Name),
 	}
 }

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -27,19 +27,12 @@ var (
 		Required: true,
 		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "BLOB_API_HTTP"),
 	}
-	BlocksPerMinuteClientFlag = &cli.IntFlag{
-		Name:     "blocks-per-minute",
-		Usage:    "The number of blocks per minute",
-		Value:    5,
+	NumBlocksClientFlag = &cli.IntFlag{
+		Name:     "num-blocks",
+		Usage:    "The number of blocks to read blob data for",
+		Value:    600,
 		Required: true,
-		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "BLOCKS_PER_MINUTE"),
-	}
-	HoursOfBlobDataClientFlag = &cli.IntFlag{
-		Name:     "hours-of-blob-data",
-		Usage:    "The number of hours of blob data to fetch",
-		Value:    2,
-		Required: true,
-		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "HOURS_OF_BLOB_DATA"),
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "NUM_BLOCKS"),
 	}
 )
 

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -38,7 +38,7 @@ var (
 
 func init() {
 	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
-	Flags = append(Flags, BeaconClientTimeoutFlag, L1BeaconClientUrlFlag, BlobApiClientUrlFlag)
+	Flags = append(Flags, BeaconClientTimeoutFlag, L1BeaconClientUrlFlag, BlobApiClientUrlFlag, NumBlocksClientFlag)
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -27,6 +27,20 @@ var (
 		Required: true,
 		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "BLOB_API_HTTP"),
 	}
+	BlocksPerMinuteClientFlag = &cli.IntFlag{
+		Name:     "blocks-per-minute",
+		Usage:    "The number of blocks per minute",
+		Value:    5,
+		Required: true,
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "BLOCKS_PER_MINUTE"),
+	}
+	HoursOfBlobDataClientFlag = &cli.IntFlag{
+		Name:     "hours-of-blob-data",
+		Usage:    "The number of hours of blob data to fetch",
+		Value:    2,
+		Required: true,
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "HOURS_OF_BLOB_DATA"),
+	}
 )
 
 func init() {

--- a/validator/service/service.go
+++ b/validator/service/service.go
@@ -29,25 +29,25 @@ const (
 	retryAttempts = 10
 )
 
-func NewValidator(l log.Logger, headerClient client.BeaconBlockHeadersProvider, beaconAPI BlobSidecarClient, blobAPI BlobSidecarClient, app context.CancelCauseFunc, hoursOfBlocks int) *ValidatorService {
+func NewValidator(l log.Logger, headerClient client.BeaconBlockHeadersProvider, beaconAPI BlobSidecarClient, blobAPI BlobSidecarClient, app context.CancelCauseFunc, numBlocks int) *ValidatorService {
 	return &ValidatorService{
-		log:           l,
-		headerClient:  headerClient,
-		beaconAPI:     beaconAPI,
-		blobAPI:       blobAPI,
-		closeApp:      app,
-		hoursOfBlocks: hoursOfBlocks,
+		log:          l,
+		headerClient: headerClient,
+		beaconAPI:    beaconAPI,
+		blobAPI:      blobAPI,
+		closeApp:     app,
+		numBlocks:    numBlocks,
 	}
 }
 
 type ValidatorService struct {
-	stopped       atomic.Bool
-	log           log.Logger
-	headerClient  client.BeaconBlockHeadersProvider
-	beaconAPI     BlobSidecarClient
-	blobAPI       BlobSidecarClient
-	closeApp      context.CancelCauseFunc
-	hoursOfBlocks int
+	stopped      atomic.Bool
+	log          log.Logger
+	headerClient client.BeaconBlockHeadersProvider
+	beaconAPI    BlobSidecarClient
+	blobAPI      BlobSidecarClient
+	closeApp     context.CancelCauseFunc
+	numBlocks    int
 }
 
 // Start starts the validator service. This will fetch the current range of blocks to validate and start the validation
@@ -64,7 +64,7 @@ func (a *ValidatorService) Start(ctx context.Context) error {
 	}
 
 	end := header.Data.Header.Message.Slot - finalizedL1Offset
-	start := end - phase0.Slot(a.hoursOfBlocks)
+	start := end - phase0.Slot(a.numBlocks)
 
 	go a.checkBlobs(ctx, start, end)
 

--- a/validator/service/service_test.go
+++ b/validator/service/service_test.go
@@ -71,7 +71,9 @@ func setup(t *testing.T) (*ValidatorService, *beacontest.StubBeaconClient, *stub
 		data: make(map[string]response),
 	}
 
-	return NewValidator(l, headerClient, beacon, blob, cancel), headerClient, beacon, blob
+	HoursOfBlobData := 5 * 2 * 60 // 2 hours of blob data at 5 blocks per minute
+
+	return NewValidator(l, headerClient, beacon, blob, cancel, HoursOfBlobData), headerClient, beacon, blob
 }
 
 func TestValidatorService_OnFetchError(t *testing.T) {

--- a/validator/service/service_test.go
+++ b/validator/service/service_test.go
@@ -71,9 +71,9 @@ func setup(t *testing.T) (*ValidatorService, *beacontest.StubBeaconClient, *stub
 		data: make(map[string]response),
 	}
 
-	HoursOfBlobData := 5 * 2 * 60 // 2 hours of blob data at 5 blocks per minute
+	numBlocks := 600
 
-	return NewValidator(l, headerClient, beacon, blob, cancel, HoursOfBlobData), headerClient, beacon, blob
+	return NewValidator(l, headerClient, beacon, blob, cancel, numBlocks), headerClient, beacon, blob
 }
 
 func TestValidatorService_OnFetchError(t *testing.T) {


### PR DESCRIPTION
This PR adds validator flags to make the hours of blob data collected configurable.

The flags are `BLOCKS_PER_MINUTE` of type int, and `HOURS_OF_BLOB_DATA` of type int.

The hours of blob data collected is calculated as `BLOCKS_PER_MINUTE * HOURS_OF_BLOB_DATA * 60`.