### PR TITLE
chore: allow validation service to process subset of formats

### DIFF
--- a/archiver/service/archiver.go
+++ b/archiver/service/archiver.go
@@ -199,7 +199,7 @@ func (a *Archiver) backfillBlobs(ctx context.Context, latest *v1.BeaconBlockHead
 		a.log.Crit("failed to read backfill_processes", "err", err)
 	}
 	backfillProcesses[common.Hash(latest.Root)] = storage.BackfillProcess{Start: *latest, Current: *latest}
-	a.dataStoreClient.WriteBackfillProcesses(ctx, backfillProcesses)
+	_ = a.dataStoreClient.WriteBackfillProcesses(ctx, backfillProcesses)
 
 	backfillLoop := func(start *v1.BeaconBlockHeader, current *v1.BeaconBlockHeader) {
 		curr, alreadyExists, err := current, false, error(nil)
@@ -219,7 +219,7 @@ func (a *Archiver) backfillBlobs(ctx context.Context, latest *v1.BeaconBlockHead
 				"startSlot", start.Header.Message.Slot,
 			)
 			delete(backfillProcesses, common.Hash(start.Root))
-			a.dataStoreClient.WriteBackfillProcesses(ctx, backfillProcesses)
+			_ = a.dataStoreClient.WriteBackfillProcesses(ctx, backfillProcesses)
 		}()
 
 		for !alreadyExists {
@@ -246,7 +246,7 @@ func (a *Archiver) backfillBlobs(ctx context.Context, latest *v1.BeaconBlockHead
 			count++
 			if count%10 == 0 {
 				backfillProcesses[common.Hash(start.Root)] = storage.BackfillProcess{Start: *start, Current: *curr}
-				a.dataStoreClient.WriteBackfillProcesses(ctx, backfillProcesses)
+				_ = a.dataStoreClient.WriteBackfillProcesses(ctx, backfillProcesses)
 			}
 		}
 	}

--- a/validator/cmd/main.go
+++ b/validator/cmd/main.go
@@ -59,6 +59,6 @@ func Main() cliapp.LifecycleAction {
 		beaconClient := service.NewBlobSidecarClient(cfg.BeaconConfig.BeaconURL)
 		blobClient := service.NewBlobSidecarClient(cfg.BlobConfig.BeaconURL)
 
-		return service.NewValidator(l, headerClient, beaconClient, blobClient, closeApp, cfg.NumBlocks), nil
+		return service.NewValidator(l, headerClient, beaconClient, blobClient, closeApp, cfg), nil
 	}
 }

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -34,11 +34,18 @@ var (
 		Required: true,
 		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "NUM_BLOCKS"),
 	}
+	ValidateFormatsFlag = &cli.StringSliceFlag{
+		Name:     "validate-formats",
+		Usage:    "The formats to validate [json, ssz]",
+		Value:    cli.NewStringSlice("json", "ssz"),
+		Required: true,
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "VALIDATE_FORMATS"),
+	}
 )
 
 func init() {
 	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
-	Flags = append(Flags, BeaconClientTimeoutFlag, L1BeaconClientUrlFlag, BlobApiClientUrlFlag, NumBlocksClientFlag)
+	Flags = append(Flags, BeaconClientTimeoutFlag, L1BeaconClientUrlFlag, BlobApiClientUrlFlag, NumBlocksClientFlag, ValidateFormatsFlag)
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/validator/service/service_test.go
+++ b/validator/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/base-org/blob-archiver/common/beacon/beacontest"
 	"github.com/base-org/blob-archiver/common/blobtest"
 	"github.com/base-org/blob-archiver/common/storage"
+	"github.com/base-org/blob-archiver/validator/flags"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -71,9 +72,10 @@ func setup(t *testing.T) (*ValidatorService, *beacontest.StubBeaconClient, *stub
 		data: make(map[string]response),
 	}
 
-	numBlocks := 600
-
-	return NewValidator(l, headerClient, beacon, blob, cancel, numBlocks), headerClient, beacon, blob
+	return NewValidator(l, headerClient, beacon, blob, cancel, flags.ValidatorConfig{
+		ValidateFormats: []string{"json", "ssz"},
+		NumBlocks:       600,
+	}), headerClient, beacon, blob
 }
 
 func TestValidatorService_OnFetchError(t *testing.T) {


### PR DESCRIPTION
### Description
Some CL clients return malformed SSZ encoded blob sidecars, this causes the blob archive validation to fail -- even when the blob archive data is correct. This PR adds a flag which allows the operator to specify which formats to check.