### PR TITLE
fix(service): store API server reference and shut it down on Stop()

### DIFF
--- a/archiver/service/archiver.go
+++ b/archiver/service/archiver.go
@@ -241,7 +241,7 @@ func (a *Archiver) waitObtainStorageLock(ctx context.Context) {
 
 	err = a.dataStoreClient.WriteLockfile(ctx, storage.Lockfile{ArchiverId: a.id, Timestamp: currentTime})
 	if err != nil {
-		a.log.Crit("failed to write to lockfile: %v", err)
+		a.log.Crit("failed to write to lockfile", "err", err)
 	}
 	a.log.Info("obtained storage lock")
 

--- a/archiver/service/service.go
+++ b/archiver/service/service.go
@@ -29,6 +29,7 @@ type ArchiverService struct {
 	stopped       atomic.Bool
 	log           log.Logger
 	metricsServer *httputil.HTTPServer
+	apiServer     *httputil.HTTPServer
 	cfg           flags.ArchiverConfig
 	metrics       metrics.Metricer
 	api           *API
@@ -53,6 +54,7 @@ func (a *ArchiverService) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start Archiver API server: %w", err)
 	}
 
+	a.apiServer = srv
 	a.log.Info("Archiver API server started", "address", srv.Addr().String())
 
 	return a.archiver.Start(ctx)
@@ -65,6 +67,12 @@ func (a *ArchiverService) Stop(ctx context.Context) error {
 	}
 	a.log.Info("Stopping Archiver")
 	a.stopped.Store(true)
+
+	if a.apiServer != nil {
+		if err := a.apiServer.Stop(ctx); err != nil {
+			return err
+		}
+	}
 
 	if a.metricsServer != nil {
 		if err := a.metricsServer.Stop(ctx); err != nil {


### PR DESCRIPTION
## What

Stores the Archiver API server reference in the `ArchiverService` struct so it can be properly shut down during `Stop()`. Also fixes a structured logging format string bug.

## Bug 1 — API server not shut down (#55)

In `Start()`, the API server is started with `httputil.StartHTTPServer()` but the returned server is only stored in a local variable. It's never assigned to the struct, so `Stop()` has no way to shut it down. The metrics server and archiver are stopped cleanly, but the API server keeps running.

This means after calling `Stop()`:
- The API server is still listening on its port
- Any in-flight HTTP requests continue processing
- Port reuse can fail on restart

**Fix:** Added `apiServer *httputil.HTTPServer` field to `ArchiverService`, assigned it in `Start()`, and added `Shutdown()` call in `Stop()` before the metrics server and archiver are stopped.

## Bug 2 — Structured log format string (#58)

In `waitObtainStorageLock`:
```go
a.log.Crit("failed to write to lockfile: %v", err)
```

The go-ethereum structured logger treats this as key-value pairs, not printf-style formatting. So `%v` becomes the key name and `err` becomes the value — but the actual error message is lost in the output.

**Fix:**
```go
a.log.Crit("failed to write to lockfile", "err", err)
```

Fixes #55
Fixes #58 (Bug 2)