### PR TITLE
fix(archiver): pass context through rearchiveRange for cancellation

### DIFF
--- a/archiver/service/api.go
+++ b/archiver/service/api.go
@@ -97,7 +97,7 @@ func (a *API) rearchiveBlocks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockStart, blockEnd, err := a.archiver.rearchiveRange(from, to)
+	blockStart, blockEnd, err := a.archiver.rearchiveRange(r.Context(), from, to)
 	if err != nil {
 		a.logger.Error("Failed to rearchive blocks", "err", err)
 

--- a/archiver/service/archiver.go
+++ b/archiver/service/archiver.go
@@ -387,7 +387,7 @@ func (a *Archiver) processBlocksUntilKnownBlock(ctx context.Context) {
 // rearchiveRange will rearchive all blocks in the range from the given start to end. It returns the start and end of the
 // range that was successfully rearchived. On any persistent errors, it will halt archiving and return the range of blocks
 // that were rearchived and the error that halted the process.
-func (a *Archiver) rearchiveRange(from uint64, to uint64) (uint64, uint64, error) {
+func (a *Archiver) rearchiveRange(ctx context.Context, from uint64, to uint64) (uint64, uint64, error) {
 	for i := from; i <= to; i++ {
 		id := strconv.FormatUint(i, 10)
 
@@ -395,8 +395,8 @@ func (a *Archiver) rearchiveRange(from uint64, to uint64) (uint64, uint64, error
 
 		l.Info("rearchiving block")
 
-		rewritten, err := retry.Do(context.Background(), rearchiveMaximumRetries, retry.Exponential(), func() (bool, error) {
-			_, _, e := a.persistBlobsForBlockToS3(context.Background(), id, true)
+		rewritten, err := retry.Do(ctx, rearchiveMaximumRetries, retry.Exponential(), func() (bool, error) {
+			_, _, e := a.persistBlobsForBlockToS3(ctx, id, true)
 
 			// If the block is not found, we can assume that the slot has been skipped
 			if e != nil {

--- a/archiver/service/archiver_test.go
+++ b/archiver/service/archiver_test.go
@@ -459,7 +459,7 @@ func TestArchiver_RearchiveRange(t *testing.T) {
 
 	from, to := blobtest.StartSlot+1, blobtest.StartSlot+4
 
-	actualFrom, actualTo, err := svc.rearchiveRange(from, to)
+	actualFrom, actualTo, err := svc.rearchiveRange(context.Background(), from, to)
 	// Should index the whole range
 	require.NoError(t, err)
 	require.Equal(t, from, actualFrom)


### PR DESCRIPTION
## What

Passes a `context.Context` through `rearchiveRange` so that cancellation propagates from both the HTTP handler and service shutdown.

## The problem

`rearchiveRange` hardcodes `context.Background()` for both the `retry.Do` call and `persistBlobsForBlockToS3`:

```go
rewritten, err := retry.Do(context.Background(), ...)
    _, _, e := a.persistBlobsForBlockToS3(context.Background(), id, true)
```

This causes two issues:

1. **Shutdown leaks**: When the archiver is stopped, any in-progress rearchive continues running indefinitely. It holds references to the beacon client and storage, preventing clean shutdown.

2. **HTTP timeout leaks**: The `/rearchive` handler has a 60-second middleware timeout. When the timeout fires, the HTTP response is aborted, but the underlying rearchive goroutine keeps running in the background — a silent resource leak for large slot ranges.

## The fix

- Added `ctx context.Context` parameter to `rearchiveRange`
- Replaced both `context.Background()` calls with `ctx`
- Updated the HTTP handler to pass `r.Context()`, which is cancelled on client disconnect or server shutdown
- Updated the test to pass `context.Background()` (no cancellation needed in tests)

Fixes #58 (Bug 1)