### PR TITLE
docs(readme): add --help flag to go run configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ docker compose up
 You can see a full list of configuration options by running:
 ```sh
 # API
-go run api/cmd/main.go
+go run api/cmd/main.go --help
 
 # Archiver
-go run archiver/cmd/main.go
+go run archiver/cmd/main.go --help
 
 ```


### PR DESCRIPTION
Fixes #62.

Running 'go run api/cmd/main.go' or 'go run archiver/cmd/main.go' without any flags starts the binary rather than showing configuration options. Verified both commands print the full list of options when --help is appended.