### PR TITLE
chore: remove obsolete version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 
 services:
   api:


### PR DESCRIPTION
Docker Compose v5 treats the top-level version field as obsolete and emits a warning on every run: 'the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion'. Removed the field to keep the compose file clean.