### PR TITLE
fix(dockerfile): align final image alpine version with builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . /app
 
 RUN make build
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 COPY --from=builder /app/archiver/bin/blob-archiver /usr/local/bin/blob-archiver
 COPY --from=builder /app/api/bin/blob-api /usr/local/bin/blob-api


### PR DESCRIPTION
Fixes #67.

The builder stage uses golang:1.24.0-alpine3.21 but the final image was pinned to alpine:3.19. Updated the final stage to alpine:3.21 to match the builder and avoid potential compatibility issues between the two stages.